### PR TITLE
Terraform 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.terraform
+
+# use a backend!
+*.tfstate*
+
+sftp-idp.zip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # terraform-aws-transfer
-This is a Terraform module to create a custom identity provider for the AWS Transfer for SFTP service.  
+
+This is a Terraform module to create a custom identity provider for the AWS Transfer for SFTP service.
 
 This module aims to set up an identity provider built on:
 * API Gateway
@@ -14,7 +15,9 @@ A DynamoDB table will be created by the resource and can be used to store SFTP u
 
 Alternatively for security, the credentials can be stored as AWS Secrets.
 
-The infrastructure code is based on the example provided (in the CF template) in the AWS Storage Blog article https://aws.amazon.com/blogs/storage/enable-password-authentication-for-aws-transfer-for-sftp-using-aws-secrets-manager/. That example uses AWS Secrets Manager which costs $0.40 per Secret so a DynamoDB based solution may be more palatable as having many users may incur high costs on smaller budgets.
+The infrastructure code is based on the example provided (in the CF template) in the AWS Storage Blog article
+https://aws.amazon.com/blogs/storage/enable-password-authentication-for-aws-transfer-for-sftp-using-aws-secrets-manager/.
+That example uses AWS Secrets Manager which costs $0.40 per Secret so a DynamoDB based solution may be more palatable as having many users may incur high costs on smaller budgets.
 
 ## Inputs
 
@@ -35,10 +38,8 @@ The infrastructure code is based on the example provided (in the CF template) in
 ```hcl-terraform
 module "sftp-idp" {
   source                = "../.."
-  dynamo_table_name      = "my-sftp-authentication-table"
 }
 ```
-
 
 ## Examples
 
@@ -46,6 +47,5 @@ module "sftp-idp" {
 * [Public with AWS Secrets](https://github.com/devopsgoat/terraform-aws-transfer/tree/master/examples/public-secrets)
 
 ## Terraform Versions
-This module supports Terraform v0.12 and v0.13
 
-
+This module supports Terraform v1.0.

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -1,31 +1,31 @@
 resource "aws_iam_role" "iam_for_apigateway_idp" {
   name = "iam_for_apigateway_idp"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = <<-EOF
     {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "apigateway.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "Service": "apigateway.amazonaws.com"
+          },
+          "Effect": "Allow",
+          "Sid": ""
+        }
+      ]
     }
-  ]
-}
-EOF
+  EOF
 }
 
 
 resource "aws_iam_role_policy_attachment" "apigateway-cloudwatchlogs" {
-  role = "${aws_iam_role.iam_for_apigateway_idp.name}"
+  role       = aws_iam_role.iam_for_apigateway_idp.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
 
 resource "aws_api_gateway_account" "eu-west-1" {
-  cloudwatch_role_arn = "${aws_iam_role.iam_for_apigateway_idp.arn}"
+  cloudwatch_role_arn = aws_iam_role.iam_for_apigateway_idp.arn
 }
 
 resource "aws_api_gateway_rest_api" "sftp-idp-secrets" {
@@ -37,40 +37,38 @@ resource "aws_api_gateway_rest_api" "sftp-idp-secrets" {
 }
 
 resource "aws_api_gateway_resource" "sftp-idp-secrets-resource-config" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  parent_id   = "${aws_api_gateway_resource.sftp-idp-secrets-resource-username.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  parent_id   = aws_api_gateway_resource.sftp-idp-secrets-resource-username.id
   path_part   = "config"
 }
 
 resource "aws_api_gateway_resource" "sftp-idp-secrets-resource-username" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  parent_id   = "${aws_api_gateway_resource.sftp-idp-secrets-resource-users.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  parent_id   = aws_api_gateway_resource.sftp-idp-secrets-resource-users.id
   path_part   = "{username}"
 }
 
 resource "aws_api_gateway_resource" "sftp-idp-secrets-resource-users" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  parent_id   = "${aws_api_gateway_resource.sftp-idp-secrets-resource-serverid.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  parent_id   = aws_api_gateway_resource.sftp-idp-secrets-resource-serverid.id
   path_part   = "users"
 }
 
 resource "aws_api_gateway_resource" "sftp-idp-secrets-resource-serverid" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  parent_id   = "${aws_api_gateway_resource.sftp-idp-secrets-resource-servers.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  parent_id   = aws_api_gateway_resource.sftp-idp-secrets-resource-servers.id
   path_part   = "{serverId}"
 }
 
 resource "aws_api_gateway_resource" "sftp-idp-secrets-resource-servers" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  parent_id   = "${aws_api_gateway_rest_api.sftp-idp-secrets.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  parent_id   = aws_api_gateway_rest_api.sftp-idp-secrets.root_resource_id
   path_part   = "servers"
 }
 
-
-
 resource "aws_api_gateway_method" "sftp-idp-secrets-method" {
-  rest_api_id   = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  resource_id   = "${aws_api_gateway_resource.sftp-idp-secrets-resource-config.id}"
+  rest_api_id   = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  resource_id   = aws_api_gateway_resource.sftp-idp-secrets-resource-config.id
   http_method   = "GET"
   authorization = "AWS_IAM"
   request_parameters = {
@@ -79,82 +77,88 @@ resource "aws_api_gateway_method" "sftp-idp-secrets-method" {
 }
 
 resource "aws_api_gateway_integration" "sftp-idp-secrets-integration" {
-  rest_api_id          = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  resource_id          = "${aws_api_gateway_resource.sftp-idp-secrets-resource-config.id}"
-  http_method = "GET"
-  integration_http_method          = "POST"
-  type                 = "AWS"
-  uri                     = "${aws_lambda_function.sftp-idp.invoke_arn}"
-  depends_on = ["null_resource.method-delay"]
+  rest_api_id             = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  resource_id             = aws_api_gateway_resource.sftp-idp-secrets-resource-config.id
+  http_method             = "GET"
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = aws_lambda_function.sftp-idp.invoke_arn
+  depends_on              = [null_resource.method-delay]
 
 
   # Transforms the incoming XML request to JSON
   request_templates = {
-    "application/json" = <<EOF
-{
-  "username": "$input.params('username')",
-  "password": "$util.escapeJavaScript($input.params('Password')).replaceAll("\\'","'")",
-  "serverId": "$input.params('serverId')"
-}
-EOF
+    "application/json" = <<-EOF
+      {
+        "username": "$input.params('username')",
+        "password": "$util.escapeJavaScript($input.params('Password')).replaceAll("\\'","'")",
+        "serverId": "$input.params('serverId')"
+      }
+    EOF
   }
 }
 
 resource "aws_api_gateway_method_response" "sftp-idp-secrets-response_200" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  resource_id = "${aws_api_gateway_resource.sftp-idp-secrets-resource-config.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  resource_id = aws_api_gateway_resource.sftp-idp-secrets-resource-config.id
   http_method = "GET"
   status_code = "200"
+
   response_models = {
-    "application/json" = "${aws_api_gateway_model.sftp-idp-secrets-model.name}"
+    "application/json" = aws_api_gateway_model.sftp-idp-secrets-model.name
   }
-  depends_on = ["null_resource.method-delay"]
+  depends_on = [null_resource.method-delay]
 }
 
 resource "aws_api_gateway_integration_response" "sftp-idp-secrets-method-IntegrationResponse" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  resource_id = "${aws_api_gateway_resource.sftp-idp-secrets-resource-config.id}"
-  http_method = "${aws_api_gateway_method.sftp-idp-secrets-method.http_method}"
-  status_code = "${aws_api_gateway_method_response.sftp-idp-secrets-response_200.status_code}"
-  //depends_on = ["null_resource.method-delay"]
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  resource_id = aws_api_gateway_resource.sftp-idp-secrets-resource-config.id
+  http_method = aws_api_gateway_method.sftp-idp-secrets-method.http_method
+  status_code = aws_api_gateway_method_response.sftp-idp-secrets-response_200.status_code
+  # depends_on = [null_resource.method-delay]
 }
 
 resource "aws_api_gateway_model" "sftp-idp-secrets-model" {
-  rest_api_id  = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
+  rest_api_id  = aws_api_gateway_rest_api.sftp-idp-secrets.id
   name         = "UserConfigResponseModel"
   description  = "API response for GetUserConfig"
   content_type = "application/json"
 
-  schema = <<EOF
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "UserUserConfig",
-  "type": "object",
-  "properties" : {
-    "HomeDirectory": {"type": "string"},
-    "Role": {"type": "string"},
-    "Policy": {"type": "string"},
-    "PublicKeys": {"type": "array", "items" : {"type" : "string"}}
-  }
-}
-EOF
+  schema = <<-EOF
+    {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "UserUserConfig",
+      "type": "object",
+      "properties" : {
+        "HomeDirectory": {"type": "string"},
+        "Role": {"type": "string"},
+        "Policy": {"type": "string"},
+        "PublicKeys": {"type": "array", "items" : {"type" : "string"}}
+      }
+    }
+  EOF
 }
 
 resource "aws_lambda_permission" "allow_apigateway" {
   statement_id  = "AllowExecutionFromApigateway"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.sftp-idp.function_name}"
+  function_name = aws_lambda_function.sftp-idp.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn = "${aws_api_gateway_rest_api.sftp-idp-secrets.execution_arn}/*/*/*"
+  source_arn    = "${aws_api_gateway_rest_api.sftp-idp-secrets.execution_arn}/*/*/*"
 }
 
 resource "aws_api_gateway_deployment" "prod" {
-  rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
+  rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
   stage_name  = ""
-  depends_on = ["aws_api_gateway_integration.sftp-idp-secrets-integration"]
+
+  depends_on  = [
+    aws_api_gateway_integration.sftp-idp-secrets-integration
+  ]
+
   variables = {
-    deployed_at = "${timestamp()}"
+    deployed_at = timestamp()
   }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -162,18 +166,18 @@ resource "aws_api_gateway_deployment" "prod" {
 
 resource "aws_api_gateway_stage" "prod" {
   stage_name    = "prod"
-  rest_api_id   = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-  deployment_id = "${aws_api_gateway_deployment.prod.id}"
+  rest_api_id   = aws_api_gateway_rest_api.sftp-idp-secrets.id
+  deployment_id = aws_api_gateway_deployment.prod.id
 }
 
-// introduce delay to let thinsg settle down to fix 404 issue creating some resources
+# introduce delay to let things settle down to fix 404 issue creating some resources
 resource "null_resource" "method-delay" {
   provisioner "local-exec" {
     command = "sleep 20"
   }
+
   triggers = {
-    rest_api_id = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
-    resource_id = "${aws_api_gateway_resource.sftp-idp-secrets-resource-config.id}"
+    rest_api_id = aws_api_gateway_rest_api.sftp-idp-secrets.id
+    resource_id = aws_api_gateway_resource.sftp-idp-secrets-resource-config.id
   }
 }
-

--- a/dynamo.tf
+++ b/dynamo.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "authentication" {
-  name           = "${var.dynamo_table_name}"
+  name           = var.dynamo_table_name
   billing_mode   = "PROVISIONED"
   read_capacity  = 20
   write_capacity = 20
@@ -11,6 +11,6 @@ resource "aws_dynamodb_table" "authentication" {
   }
 
   tags = {
-    Name        = "${var.dynamo_table_name}"
+    Name = var.dynamo_table_name
   }
 }

--- a/examples/public-dynamo/.terraform.lock.hcl
+++ b/examples/public-dynamo/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.59.0"
+  hashes = [
+    "h1:cN7sJwv3gwrkgbZS40vbV6IOnwHY0WWsUKPQf1gErv4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
+  ]
+}

--- a/examples/public-dynamo/README.md
+++ b/examples/public-dynamo/README.md
@@ -1,6 +1,6 @@
 # Simple Public SFTP example using DynamoDB
 
-This example creates a simple public facing AWS Transfer for SFTP service using the API_GATEWAY identity provider. 
+This example creates a simple public facing AWS Transfer for SFTP service using the API_GATEWAY identity provider.
 
 A bucket will be created to store the files along with an IAM role for the user to access the service.
 

--- a/examples/public-dynamo/README.md
+++ b/examples/public-dynamo/README.md
@@ -10,24 +10,52 @@ A bucket will be created to store the files along with an IAM role for the user 
     $ terraform plan
     $ terraform apply
 
-
 ## Example User Configuration
 
 Once the service has been started, a user can be set up by adding a record to the DynamoDB table as follows:
 
 NOTE: All fields are ***String*** fields including the ***HomeDirectoryDetails*** which should contain a JSON string
 
-
 | UserId | HomeDirectoryDetails | Role | Password |
 |--------|----------------------|------|----------|
-| user1 | [{\"Entry\": \"/\", \"Target\": \"/test.devopsgoat/${Transfer:UserName}\"}] | arn:aws:iam::[account id]:role/transfer-user-iam-role | Password1 |
+| user1 | [{"Entry": "/", "Target": "/test.devopsgoat/${Transfer:UserName}"}] | arn:aws:iam::[account id]:role/transfer-user-iam-role | Password1 |
 
 This will create a user **user1** which is chroot'd to the **/test.devopsgoat/user1** virtual directory in S3.
 
+### Create User with a Password
+```bash
+aws dynamodb put-item \
+  --table-name my-sftp-authentication-table \
+  --item '{"UserId": {"S": "user1"}, "HomeDirectoryDetails": {"L": [{"M": {"Entry": {"S": "/"}, "Target": {"S": "/test.devopsgoat/${Transfer:UserName}"}}}]}, "Role": {"S": "arn:aws:iam::[account id]:role/transfer-user-iam-role"}, "Password": {"S": "Password1"}}'
+```
+
+#### Authenticate
+
+```bash
+sftp user1@<aws_transfer_server.sftp.endpoint>
+```
+
+### Create a User with an SSH Key
+
+Replace the `PublicKey` value below:
+
+```bash
+aws dynamodb put-item \
+  --table-name my-sftp-authentication-table \
+  --item '{"UserId": {"S": "user1"}, "HomeDirectoryDetails": {"L": [{"M": {"Entry": {"S": "/"}, "Target": {"S": "/test.devopsgoat/${Transfer:UserName}"}}}]}, "Role": {"S": "arn:aws:iam::[account id]:role/transfer-user-iam-role"}, "PublicKey": { "S": "ssh-rsa ... must be a valid rsa public key" }}'
+```
+
+#### Authenticate
+The identity must be explicitly declared
+
+```bash
+sftp -i ~/.ssh/id_rsa user1@<aws_transfer_server.sftp.endpoint>
+```
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| sftp-endpoint | The endpoint of the SFTP service |
-
+| dynamo_table_name | The DynamoDB table name to be used in `--table-name` |
+| endpoint | The endpoint of the SFTP service |
+| role | The IAM Role that must be assigned to users |

--- a/examples/public-dynamo/bucket.tf
+++ b/examples/public-dynamo/bucket.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "sftp" {
-    bucket = "test.devopsgoat"
-    acl = "private"
+  bucket = "test.devopsgoat"
+  acl    = "private"
 }

--- a/examples/public-dynamo/iam.tf
+++ b/examples/public-dynamo/iam.tf
@@ -1,54 +1,54 @@
 resource "aws_iam_role" "foo" {
   name = "transfer-user-iam-role"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "transfer.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-        }
-    ]
-}
-EOF
+  assume_role_policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "transfer.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role_policy" "foo" {
   name = "transfer-user-iam-policy"
-  role = "${aws_iam_role.foo.id}"
+  role = aws_iam_role.foo.id
 
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowListingOfUserFolder",
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "${aws_s3_bucket.sftp.arn}"
-            ]
-        },
-        {
-            "Sid": "HomeDirObjectAccess",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:DeleteObjectVersion",
-                "s3:DeleteObject",
-                "s3:GetObjectVersion"
-            ],
-            "Resource": "${aws_s3_bucket.sftp.arn}/*"
-        }
-    ]
-}
-POLICY
+  policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowListingOfUserFolder",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "${aws_s3_bucket.sftp.arn}"
+                ]
+            },
+            {
+                "Sid": "HomeDirObjectAccess",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:DeleteObjectVersion",
+                    "s3:DeleteObject",
+                    "s3:GetObjectVersion"
+                ],
+                "Resource": ["${aws_s3_bucket.sftp.arn}","${aws_s3_bucket.sftp.arn}/*"]
+            }
+        ]
+    }
+  POLICY
 }

--- a/examples/public-dynamo/output.tf
+++ b/examples/public-dynamo/output.tf
@@ -1,8 +1,8 @@
 output "endpoint" {
-    value = "${aws_transfer_server.sftp.endpoint}"
+  value = aws_transfer_server.sftp.endpoint
 }
 
 output "role" {
-    value = "${aws_iam_role.foo.arn}"
+  value = aws_iam_role.foo.arn
 }
 

--- a/examples/public-dynamo/output.tf
+++ b/examples/public-dynamo/output.tf
@@ -1,3 +1,7 @@
+output "dynamo_table_name" {
+  value = module.idp.dynamo_table_name
+}
+
 output "endpoint" {
   value = aws_transfer_server.sftp.endpoint
 }
@@ -5,4 +9,3 @@ output "endpoint" {
 output "role" {
   value = aws_iam_role.foo.arn
 }
-

--- a/examples/public-dynamo/sftp.tf
+++ b/examples/public-dynamo/sftp.tf
@@ -1,122 +1,110 @@
-provider "aws" {
-  region  = "eu-west-2"
-}
-
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "sftp" {
-  // role for SFTP server
+  # role for SFTP server
   name = "sftp-server-iam-role"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "transfer.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-        }
-    ]
-}
-EOF
+  assume_role_policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "transfer.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role" "sftp_log" {
-  // log role for SFTP server
+  # log role for SFTP server
   name = "sftp-server-iam-log-role"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "transfer.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-        }
-    ]
-}
-EOF
+  assume_role_policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "transfer.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role_policy" "sftp" {
-  // policy to allow invocation of IdP API
+  # policy to allow invocation of IdP API
   name = "sftp-server-iam-policy"
-  role = "${aws_iam_role.sftp.id}"
+  role = aws_iam_role.sftp.id
 
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "InvokeApi",
-			"Effect": "Allow",
-			"Action": [
-				"execute-api:Invoke"
-			],
-			"Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${module.idp.rest_api_id}/${module.idp.rest_api_stage_name}/GET/*"
-		},
-		{
-			"Sid": "ReadApi",
-			"Effect": "Allow",
-			"Action": [
-				"apigateway:GET"
-			],
-			"Resource": "*"
-		}
-	]
-}
-POLICY
+  policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "InvokeApi",
+          "Effect": "Allow",
+          "Action": [
+            "execute-api:Invoke"
+          ],
+          "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${module.idp.rest_api_id}/${module.idp.rest_api_stage_name}/GET/*"
+        },
+        {
+          "Sid": "ReadApi",
+          "Effect": "Allow",
+          "Action": [
+            "apigateway:GET"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role_policy" "sftp_log" {
-  // policy to allow logging to Cloudwatch
+  # policy to allow logging to Cloudwatch
   name = "sftp-server-iam-log-policy"
-  role = "${aws_iam_role.sftp_log.id}"
+  role = aws_iam_role.sftp_log.id
 
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [{
-			"Sid": "AllowFullAccesstoCloudWatchLogs",
-			"Effect": "Allow",
-			"Action": [
-				"logs:*"
-			],
-			"Resource": "*"
-		}
-	]
-}
-POLICY
+  policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+          "Sid": "AllowFullAccesstoCloudWatchLogs",
+          "Effect": "Allow",
+          "Action": [
+            "logs:*"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+  POLICY
 }
 
 resource "aws_transfer_server" "sftp" {
   identity_provider_type = "API_GATEWAY"
-  logging_role           = "${aws_iam_role.sftp_log.arn}"
-  // url from output of the module
-  url = "${module.idp.invoke_url}"
-  invocation_role = "${aws_iam_role.sftp.arn}"
-  endpoint_type = "PUBLIC"
+  logging_role           = aws_iam_role.sftp_log.arn
+  url                    = module.idp.invoke_url # url from output of the module
+  invocation_role        = aws_iam_role.sftp.arn
+  endpoint_type          = "PUBLIC"
 
   tags = {
     NAME = "sftp-server"
   }
 }
 
-
 module "idp" {
   source = "../.."
-  dynamo_table_name = "my-sftp-authentication-table"
 }
-
-
-
-
-

--- a/examples/public-dynamo/versions.tf
+++ b/examples/public-dynamo/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/examples/public-secrets/.terraform.lock.hcl
+++ b/examples/public-secrets/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.59.0"
+  hashes = [
+    "h1:cN7sJwv3gwrkgbZS40vbV6IOnwHY0WWsUKPQf1gErv4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
+  ]
+}

--- a/examples/public-secrets/README.md
+++ b/examples/public-secrets/README.md
@@ -24,26 +24,27 @@ This will create a user **user1** which is chroot'd to the **/test.devopsgoat/us
 
 For guidance the following example code will create this Secret:
 
-    resource "aws_secretsmanager_secret" "secret" {
-      name                = "SFTP/tester"
-    }
+```
+resource "aws_secretsmanager_secret" "secret" {
+  name                = "SFTP/user1"
+}
 
-
-    resource "aws_secretsmanager_secret_version" "secret" {
-      secret_id     = "${aws_secretsmanager_secret.secret.id}"
-      secret_string = <<EOF
+resource "aws_secretsmanager_secret_version" "secret" {
+  secret_id     = "${aws_secretsmanager_secret.secret.id}"
+  secret_string = <<-EOF
     {
       "HomeDirectoryDetails": "[{\"Entry\": \"/\", \"Target\": \"/test.devopsgoat/$${Transfer:UserName}\"}]",
-      "Password": "tester159",
+      "Password": "Password1",
       "Role": "arn:aws:iam::XXXXXXX:role/transfer-user-iam-role",
-      "UserId": "tester"
+      "UserId": "user1"
     }
-    EOF
-    }
-
+  EOF
+}
+```
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| sftp-endpoint | The endpoint of the SFTP service |
+| endpoint | The endpoint of the SFTP service |
+| role | The IAM Role that must be assigned to users |

--- a/examples/public-secrets/README.md
+++ b/examples/public-secrets/README.md
@@ -10,13 +10,11 @@ A bucket will be created to store the files along with an IAM role for the user 
     $ terraform plan
     $ terraform apply
 
-
 ## Example User Configuration
 
 Once the service has been started, a user can be set up by adding an AWS Secret:
 
 The secret name should be SFTP/user1 for a user login **user1**
-
 
 | UserId | HomeDirectoryDetails | Role | Password |
 |--------|----------------------|------|----------|
@@ -29,8 +27,8 @@ For guidance the following example code will create this Secret:
     resource "aws_secretsmanager_secret" "secret" {
       name                = "SFTP/tester"
     }
-    
-    
+
+
     resource "aws_secretsmanager_secret_version" "secret" {
       secret_id     = "${aws_secretsmanager_secret.secret.id}"
       secret_string = <<EOF
@@ -49,4 +47,3 @@ For guidance the following example code will create this Secret:
 | Name | Description |
 |------|-------------|
 | sftp-endpoint | The endpoint of the SFTP service |
-

--- a/examples/public-secrets/bucket.tf
+++ b/examples/public-secrets/bucket.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "sftp" {
-    bucket = "test.devopsgoat"
-    acl = "private"
+  bucket = "test.devopsgoat"
+  acl    = "private"
 }

--- a/examples/public-secrets/iam.tf
+++ b/examples/public-secrets/iam.tf
@@ -19,21 +19,36 @@ EOF
 
 resource "aws_iam_role_policy" "foo" {
   name = "transfer-user-iam-policy"
-  role = "${aws_iam_role.foo.id}"
+  role = aws_iam_role.foo.id
 
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowFullAccesstoS3",
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": ["${aws_s3_bucket.sftp.arn}","${aws_s3_bucket.sftp.arn}/*"]
-        }
-    ]
-}
-POLICY
+  policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowListingOfUserFolder",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                    "${aws_s3_bucket.sftp.arn}"
+                ]
+            },
+            {
+                "Sid": "HomeDirObjectAccess",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:DeleteObjectVersion",
+                    "s3:DeleteObject",
+                    "s3:GetObjectVersion"
+                ],
+                "Resource": ["${aws_s3_bucket.sftp.arn}","${aws_s3_bucket.sftp.arn}/*"]
+            }
+        ]
+    }
+  POLICY
 }

--- a/examples/public-secrets/output.tf
+++ b/examples/public-secrets/output.tf
@@ -1,8 +1,7 @@
 output "endpoint" {
-    value = "${aws_transfer_server.sftp.endpoint}"
+  value = aws_transfer_server.sftp.endpoint
 }
 
 output "role" {
-    value = "${aws_iam_role.foo.arn}"
+  value = aws_iam_role.foo.arn
 }
-

--- a/examples/public-secrets/sftp.tf
+++ b/examples/public-secrets/sftp.tf
@@ -107,5 +107,7 @@ resource "aws_transfer_server" "sftp" {
 
 module "idp" {
   source      = "../.."
+
   creds_store = "secrets"
+  server_id = aws_transfer_server.sftp.id
 }

--- a/examples/public-secrets/sftp.tf
+++ b/examples/public-secrets/sftp.tf
@@ -109,5 +109,4 @@ module "idp" {
   source      = "../.."
 
   creds_store = "secrets"
-  server_id = aws_transfer_server.sftp.id
 }

--- a/examples/public-secrets/sftp.tf
+++ b/examples/public-secrets/sftp.tf
@@ -1,123 +1,111 @@
-provider "aws" {
-  region  = "eu-west-2"
-}
-
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+# role for SFTP server
 resource "aws_iam_role" "sftp" {
-  // role for SFTP server
   name = "sftp-server-iam-role"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "transfer.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-        }
-    ]
-}
-EOF
+  assume_role_policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "transfer.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role" "sftp_log" {
-  // log role for SFTP server
+  # log role for SFTP server
   name = "sftp-server-iam-log-role"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "transfer.amazonaws.com"
-        },
-        "Action": "sts:AssumeRole"
-        }
-    ]
-}
-EOF
+  assume_role_policy = <<-POLICY
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "transfer.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role_policy" "sftp" {
-  // policy to allow invocation of IdP API
+  # policy to allow invocation of IdP API
   name = "sftp-server-iam-policy"
-  role = "${aws_iam_role.sftp.id}"
+  role = aws_iam_role.sftp.id
 
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "InvokeApi",
-			"Effect": "Allow",
-			"Action": [
-				"execute-api:Invoke"
-			],
-			"Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${module.idp.rest_api_id}/${module.idp.rest_api_stage_name}/GET/*"
-		},
-		{
-			"Sid": "ReadApi",
-			"Effect": "Allow",
-			"Action": [
-				"apigateway:GET"
-			],
-			"Resource": "*"
-		}
-	]
-}
-POLICY
+  policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "InvokeApi",
+          "Effect": "Allow",
+          "Action": [
+            "execute-api:Invoke"
+          ],
+          "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${module.idp.rest_api_id}/${module.idp.rest_api_stage_name}/GET/*"
+        },
+        {
+          "Sid": "ReadApi",
+          "Effect": "Allow",
+          "Action": [
+            "apigateway:GET"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+  POLICY
 }
 
 resource "aws_iam_role_policy" "sftp_log" {
-  // policy to allow logging to Cloudwatch
+  # policy to allow logging to Cloudwatch
   name = "sftp-server-iam-log-policy"
-  role = "${aws_iam_role.sftp_log.id}"
+  role = aws_iam_role.sftp_log.id
 
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [{
-			"Sid": "AllowFullAccesstoCloudWatchLogs",
-			"Effect": "Allow",
-			"Action": [
-				"logs:*"
-			],
-			"Resource": "*"
-		}
-	]
-}
-POLICY
+  policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+          "Sid": "AllowFullAccesstoCloudWatchLogs",
+          "Effect": "Allow",
+          "Action": [
+            "logs:*"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+  POLICY
 }
 
 resource "aws_transfer_server" "sftp" {
   identity_provider_type = "API_GATEWAY"
-  logging_role           = "${aws_iam_role.sftp_log.arn}"
-  // url from output of the module
-  url = "${module.idp.invoke_url}"
-  invocation_role = "${aws_iam_role.sftp.arn}"
-  endpoint_type = "PUBLIC"
+  logging_role           = aws_iam_role.sftp_log.arn
+  url                    = module.idp.invoke_url # url from output of the module
+  invocation_role        = aws_iam_role.sftp.arn
+  endpoint_type          = "PUBLIC"
 
   tags = {
     NAME = "sftp-server"
   }
 }
 
-
 module "idp" {
-  source = "../.."
-  dynamo_table_name = "my-sftp-authentication-table"
+  source      = "../.."
   creds_store = "secrets"
 }
-
-
-
-
-

--- a/examples/public-secrets/versions.tf
+++ b/examples/public-secrets/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,79 +1,79 @@
 resource "aws_lambda_function" "sftp-idp" {
   filename         = "${path.module}/sftp-idp.zip"
   function_name    = "sftp-idp"
-  role             = "${aws_iam_role.iam_for_lambda_idp.arn}"
+  role             = aws_iam_role.iam_for_lambda_idp.arn
   handler          = "index.lambda_handler"
-  source_code_hash = "${data.archive_file.sftp-idp.output_base64sha256}"
+  source_code_hash = data.archive_file.sftp-idp.output_base64sha256
   runtime          = "python3.7"
+
   environment {
     variables = {
-      "${var.creds_store == "dynamo" ? "dynamo_table_name" : "SecretsManagerRegion"}" = "${var.creds_store == "dynamo" ? aws_dynamodb_table.authentication.name : data.aws_region.current.name}"
+      "${local.auth_source_name}" = local.auth_source_value
     }
   }
 }
 
-
 data "archive_file" "sftp-idp" {
   type        = "zip"
-  source_dir = "${path.module}/lambda/source/"
+  source_dir  = "${path.module}/lambda/source/"
   output_path = "${path.module}/sftp-idp.zip"
 }
 
 resource "aws_iam_role" "iam_for_lambda_idp" {
   name = "iam_for_lambda_idp"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = <<-EOF
     {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          },
+          "Effect": "Allow",
+          "Sid": ""
+        }
+      ]
     }
-  ]
-}
-EOF
+  EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs_idp" {
-  role = "${aws_iam_role.iam_for_lambda_idp.name}"
+  role       = aws_iam_role.iam_for_lambda_idp.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_policy" "sftp-idp" {
-  name = "sftp-idp"
-  path = "/"
+  name        = "sftp-idp"
+  path        = "/"
   description = "IAM policy IdP service for SFTP in Lambda"
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "dynamodb:GetItem",
-            "Resource": "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.authentication.name}"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "secretsmanager:GetSecretValue",
-            "Resource": "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:SFTP/*"
-        }
-    ]
-}
-EOF
+  policy = <<-EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "dynamodb:GetItem",
+                "Resource": "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.authentication.name}"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "secretsmanager:GetSecretValue",
+                "Resource": "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:SFTP/*"
+            }
+        ]
+    }
+  EOF
 }
 
 resource "aws_iam_role_policy_attachment" "sftp-idp1" {
-  role = "${aws_iam_role.iam_for_lambda_idp.name}"
-  policy_arn = "${aws_iam_policy.sftp-idp.arn}"
+  role       = aws_iam_role.iam_for_lambda_idp.name
+  policy_arn = aws_iam_policy.sftp-idp.arn
 }
 
 resource "aws_iam_role_policy_attachment" "sftp-idp2" {
-  role = "${aws_iam_role.iam_for_lambda_idp.name}"
+  role       = aws_iam_role.iam_for_lambda_idp.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }

--- a/lambda/source/index.py
+++ b/lambda/source/index.py
@@ -18,7 +18,6 @@ def lambda_handler(event, context):
         print("No authentication method set")
         return {}
 
-
     if 'username' not in event or 'serverId' not in event:
         print("Incoming username or serverId missing  - Unexpected")
         return response_data
@@ -61,7 +60,7 @@ def lambda_handler(event, context):
 
     # If we've got this far then we've either authenticated the user by password or we're using SSH public key auth and
     # we've begun constructing the data response. Check for each key value pair.
-    # These are required so set to empty string if missing
+    # These are required so set to empty string if missing.
     if 'Role' in resp_dict:
         resp_data['Role'] = resp_dict['Role']
     else:

--- a/lambda/source/index.py
+++ b/lambda/source/index.py
@@ -73,7 +73,7 @@ def lambda_handler(event, context):
 
     if 'HomeDirectoryDetails' in resp_dict:
         print("HomeDirectoryDetails found - Applying setting for virtual folders")
-        resp_data['HomeDirectoryDetails'] = resp_dict['HomeDirectoryDetails']
+        resp_data['HomeDirectoryDetails'] = json.dumps(resp_dict['HomeDirectoryDetails'])
         resp_data['HomeDirectoryType'] = "LOGICAL"
     elif 'HomeDirectory' in resp_dict:
         print("HomeDirectory found - Cannot be used with HomeDirectoryDetails")
@@ -81,27 +81,22 @@ def lambda_handler(event, context):
     else:
         print("HomeDirectory not found - Defaulting to /")
 
-    print("Completed Response Data: "+json.dumps(resp_data))
+    print("Completed Response Data: " + json.dumps(resp_data))
     return resp_data
 
 def auth_dynamo(id):
-    client = boto3.client('dynamodb')
-    ret={}
+    client = boto3.resource('dynamodb')
+    table = client.Table(os.environ['dynamo_table_name'])
     try:
         # lookup the user in the table
-        response = client.get_item(
-            TableName=os.environ['dynamo_table_name'],
-            Key={
-                'UserId': {
-                    'S': id
-                }
+        response = table.get_item(
+            Key = {
+                'UserId': id
             }
         )
         # Extract the values from the response
         if response.get("Item"):
-            for k, v in response.get("Item").items():
-                ret[k]=list(v.values())[0]
-            return ret
+            return response.get("Item")
         else:
             return None
     except ClientError as err:

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  is_dynamo             = var.creds_store == "dynamo"
+  auth_source_name  = local.is_dynamo ? "dynamo_table_name" : "SecretsManagerRegion"
+  auth_source_value = local.is_dynamo ? aws_dynamodb_table.authentication.name : data.aws_region.current.name
+}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
-
-variable "creds_store" {
-    default = "dynamo"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "invoke_url" {
-    value = "${aws_api_gateway_stage.prod.invoke_url}"
+  value = aws_api_gateway_stage.prod.invoke_url
 }
 
 output "rest_api_id" {
-    value = "${aws_api_gateway_rest_api.sftp-idp-secrets.id}"
+  value = aws_api_gateway_rest_api.sftp-idp-secrets.id
 }
 
 output "rest_api_stage_name" {
-    value = "${aws_api_gateway_stage.prod.stage_name}"
+  value = aws_api_gateway_stage.prod.stage_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "dynamo_table_name" {
+  value = var.dynamo_table_name
+}
+
 output "invoke_url" {
   value = aws_api_gateway_stage.prod.invoke_url
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,8 @@
-variable "dynamo_table_name" {}
+variable "creds_store" {
+  description = "If this is not `dynamo` the IdP will use the Secrets Manager for authenication."
+  default = "dynamo"
+}
+
+variable "dynamo_table_name" {
+  default = "my-sftp-authentication-table"
+}


### PR DESCRIPTION
Update `terraform-aws-transfer` to Terraform 1.0 syntax and standards.

- Fix DynamoDB data handling
- Use `locals` to clean up that complicated Lambda ENV variable setting
- Make DynamoDB & Secrets examples match more closely
- Run `terraform fmt` on all dirs
- Replace tabs with strings
- Standardize HEREDOC usage

This has been confirmed to work for me in `us-west-2` with both examples: Dynamo & Secrets.

Sorry this is such a large PR but it's mostly white space changes.