### PR TITLE
Add support for EFS POSIX profile

### DIFF
--- a/lambda/source/index.py
+++ b/lambda/source/index.py
@@ -149,6 +149,11 @@ def build_response(secret_dict, auth_type, input_protocol):
     if policy:
         response_data["Policy"] = policy
 
+    # Add support for EFS-required POSIX policy
+    posixProfile = lookup(secret_dict, "PosixProfile", input_protocol)
+    if posixProfile:
+        response_data["PosixProfile"] = posixProfile
+
     # External Auth providers support chroot
     # and virtual folder assignments so we'll check for that
     home_directory_details = lookup(secret_dict,


### PR DESCRIPTION
When using a Transfer Family server backed by EFS, it's required to provide a PosixProfile in the lambda response. This PR adds the ability to define that profile within your AWS Secret. 